### PR TITLE
On Raspberry Pi 3 and Raspberry Pi Zero W, the PL011 UART is connecte…

### DIFF
--- a/configs/pi_3_b/scripts/boot.cmd
+++ b/configs/pi_3_b/scripts/boot.cmd
@@ -1,3 +1,3 @@
 firmwareload 0x10000000
-setenv bootargs console=ttyAMA0,115200 earlyprintk root=/dev/root rootwait panic=10 loglevel=4
+setenv bootargs console=ttyS1,115200 earlyprintk root=/dev/root rootwait panic=10 loglevel=4
 bootm 0x10000000

--- a/pi-boot/config.txt
+++ b/pi-boot/config.txt
@@ -54,3 +54,6 @@
 
 # Enable audio (loads snd_bcm2835)
 dtparam=audio=on
+
+# for pi 3 b
+enable_uart=1


### PR DESCRIPTION
…d to the BT module, while the mini UART is used for Linux console output. On all other models the PL011 is used for the Linux console output.