### PR TITLE
Enable htop on orange pi zero

### DIFF
--- a/applications/network_manager/network_manager.cpp
+++ b/applications/network_manager/network_manager.cpp
@@ -69,7 +69,15 @@ void network_manager_init()
     if (_network_manager_wake_up("eth0")) {
         // start udhcp
         app::serviceDhcpC::getInstance()->init();
+#if defined (orange_pi_zero)
+        // hack, we're using orange_pi_zero as vpn server with bridge mode.
+        system("/bin/busybox brctl addbr br0");
+        system("/bin/busybox brctl addif br0 eth0");
+        _network_manager_wake_up("br0");
+        app::serviceDhcpC::getInstance()->addManagedInterfaces("br0");
+#else
         app::serviceDhcpC::getInstance()->addManagedInterfaces("eth0");
+#endif
         app::serviceDhcpC::getInstance()->start();
     }
 

--- a/configs/orange_pi_zero/buildroot/config
+++ b/configs/orange_pi_zero/buildroot/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Buildroot 2017.02.10-g7bbf54f8e-dirty Configuration
+# Buildroot 2017.02.10-ga9eee98e1-dirty Configuration
 #
 BR2_HAVE_DOT_CONFIG=y
 BR2_HOST_GCC_AT_LEAST_4_5=y
@@ -2056,7 +2056,8 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 # libunistring needs a toolchain w/ wchar
 #
 # BR2_PACKAGE_LINENOISE is not set
-# BR2_PACKAGE_NCURSES is not set
+BR2_PACKAGE_NCURSES=y
+BR2_PACKAGE_NCURSES_TARGET_PROGS=y
 
 #
 # newt needs a toolchain w/ wchar, dynamic library
@@ -2573,7 +2574,7 @@ BR2_PACKAGE_EFIVAR_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_FTOP is not set
 # BR2_PACKAGE_GETENT is not set
-# BR2_PACKAGE_HTOP is not set
+BR2_PACKAGE_HTOP=y
 BR2_PACKAGE_INITSCRIPTS=y
 
 #


### PR DESCRIPTION
There are two commits for this pull request:
- enable htop for orange_pi_zero
- hack, we're using orange_pi_zero as vpn server with bridge mode
